### PR TITLE
Fix lifetime registration scanning

### DIFF
--- a/AspNetCore.DIToolKit/ServiceCollectionExtensions.cs
+++ b/AspNetCore.DIToolKit/ServiceCollectionExtensions.cs
@@ -18,10 +18,14 @@ public static class ServiceCollectionExtensions
         scan.FromAssemblies(assemblies)
             .AddClasses(z => z.AssignableTo<LifeTime.ITransient>())
             .AsImplementedInterfaces()
-            .WithTransientLifetime()
+            .WithTransientLifetime();
+
+        scan.FromAssemblies(assemblies)
             .AddClasses(z => z.AssignableTo<LifeTime.IScoped>())
             .AsImplementedInterfaces()
-            .WithScopedLifetime()
+            .WithScopedLifetime();
+
+        scan.FromAssemblies(assemblies)
             .AddClasses(z => z.AssignableTo<LifeTime.ISingleton>())
             .AsImplementedInterfaces()
             .WithSingletonLifetime();


### PR DESCRIPTION
## Summary
- ensure each lifetime registration scans assemblies separately

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6892e02f7120832babc304c21c058d85