### PR TITLE
refactor: rename service registration extension

### DIFF
--- a/AspNetCore.DIToolKit/ServiceCollectionExtensions.cs
+++ b/AspNetCore.DIToolKit/ServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ namespace AspNetCore.DIToolKit;
 
 public static class ServiceCollectionExtensions
 {
-    public static void ConfigureServicesByLifeTimeCycle(this IServiceCollection serviceCollection, IConfiguration configuration)
+    public static void ConfigureServicesByLifetime(this IServiceCollection serviceCollection, IConfiguration configuration)
     {
         serviceCollection.Scan(ConfigureByAssemblySelector);
     }


### PR DESCRIPTION
## Summary
- rename `ConfigureServicesByLifeTimeCycle` to `ConfigureServicesByLifetime`

## Testing
- `dotnet build AspNetCore.DIToolKit.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892e215ae28832ba7ecf593818782ac