### PR TITLE
Filter dynamic assemblies and add registration tests

### DIFF
--- a/AspNetCore.DIToolKit.Tests/AspNetCore.DIToolKit.Tests.csproj
+++ b/AspNetCore.DIToolKit.Tests/AspNetCore.DIToolKit.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AspNetCore.DIToolKit\AspNetCore.DIToolKit.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/AspNetCore.DIToolKit.Tests/ServiceRegistrationTests.cs
+++ b/AspNetCore.DIToolKit.Tests/ServiceRegistrationTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AspNetCore.DIToolKit.Tests;
+
+public interface ITransientService {}
+public class TransientService : ITransientService, LifeTime.ITransient {}
+
+public interface IScopedService {}
+public class ScopedService : IScopedService, LifeTime.IScoped {}
+
+public interface ISingletonService {}
+public class SingletonService : ISingletonService, LifeTime.ISingleton {}
+
+public class ServiceRegistrationTests
+{
+    [Fact]
+    public void ConfigureServicesByLifeTimeCycle_RegistersServicesWithCorrectLifetime()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        services.ConfigureServicesByLifeTimeCycle(configuration);
+
+        var provider = services.BuildServiceProvider();
+
+        var transient1 = provider.GetService<ITransientService>();
+        var transient2 = provider.GetService<ITransientService>();
+        Assert.NotNull(transient1);
+        Assert.NotNull(transient2);
+        Assert.NotSame(transient1, transient2);
+
+        using var scope1 = provider.CreateScope();
+        using var scope2 = provider.CreateScope();
+        var scoped1 = scope1.ServiceProvider.GetService<IScopedService>();
+        var scoped2 = scope1.ServiceProvider.GetService<IScopedService>();
+        var scoped3 = scope2.ServiceProvider.GetService<IScopedService>();
+        Assert.NotNull(scoped1);
+        Assert.Same(scoped1, scoped2);
+        Assert.NotSame(scoped1, scoped3);
+
+        var singleton1 = provider.GetService<ISingletonService>();
+        var singleton2 = provider.GetService<ISingletonService>();
+        Assert.NotNull(singleton1);
+        Assert.Same(singleton1, singleton2);
+    }
+}

--- a/AspNetCore.DIToolKit.sln
+++ b/AspNetCore.DIToolKit.sln
@@ -2,15 +2,21 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.DIToolKit", "AspNetCore.DIToolKit\AspNetCore.DIToolKit.csproj", "{EA2BD0E0-98D2-4855-9EEE-186B63316470}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.DIToolKit.Tests", "AspNetCore.DIToolKit.Tests\AspNetCore.DIToolKit.Tests.csproj", "{0EDB8783-7E1B-4DAE-A503-AB04B7C1F3C1}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.Build.0 = Release|Any CPU
+                {0EDB8783-7E1B-4DAE-A503-AB04B7C1F3C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0EDB8783-7E1B-4DAE-A503-AB04B7C1F3C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0EDB8783-7E1B-4DAE-A503-AB04B7C1F3C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0EDB8783-7E1B-4DAE-A503-AB04B7C1F3C1}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/AspNetCore.DIToolKit/ServiceCollectionExtensions.cs
+++ b/AspNetCore.DIToolKit/ServiceCollectionExtensions.cs
@@ -13,7 +13,11 @@ public static class ServiceCollectionExtensions
 
     private static void ConfigureByAssemblySelector(IAssemblySelector scan)
     {
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        var assemblies = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Where(a => !a.IsDynamic)
+            .Where(a => !a.FullName.StartsWith("System", StringComparison.Ordinal) &&
+                        !a.FullName.StartsWith("Microsoft", StringComparison.Ordinal));
 
         scan.FromAssemblies(assemblies)
             .AddClasses(z => z.AssignableTo<LifeTime.ITransient>())


### PR DESCRIPTION
## Summary
- ignore dynamic and framework assemblies while scanning for services
- add unit tests verifying transient, scoped and singleton registrations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892e215cd24832b80794524e2437186