### PR TITLE
Add tests for service registration lifetimes

### DIFF
--- a/AspNetCore.DIToolKit.Tests/AspNetCore.DIToolKit.Tests.csproj
+++ b/AspNetCore.DIToolKit.Tests/AspNetCore.DIToolKit.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspNetCore.DIToolKit\AspNetCore.DIToolKit.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/AspNetCore.DIToolKit.Tests/ServiceCollectionExtensionsTests.cs
+++ b/AspNetCore.DIToolKit.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,39 @@
+using AspNetCore.DIToolKit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AspNetCore.DIToolKit.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void ConfigureServicesByLifeTimeCycle_RegistersExpectedLifetimes()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.ConfigureServicesByLifeTimeCycle(configuration);
+
+        var singletonDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ISingletonTest));
+        var scopedDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IScopedTest));
+        var transientDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ITransientTest));
+
+        Assert.NotNull(singletonDescriptor);
+        Assert.NotNull(scopedDescriptor);
+        Assert.NotNull(transientDescriptor);
+
+        Assert.Equal(ServiceLifetime.Singleton, singletonDescriptor!.Lifetime);
+        Assert.Equal(ServiceLifetime.Scoped, scopedDescriptor!.Lifetime);
+        Assert.Equal(ServiceLifetime.Transient, transientDescriptor!.Lifetime);
+    }
+
+    public interface ISingletonTest { }
+    public class SingletonTest : ISingletonTest, LifeTime.ISingleton { }
+
+    public interface IScopedTest { }
+    public class ScopedTest : IScopedTest, LifeTime.IScoped { }
+
+    public interface ITransientTest { }
+    public class TransientTest : ITransientTest, LifeTime.ITransient { }
+}

--- a/AspNetCore.DIToolKit.sln
+++ b/AspNetCore.DIToolKit.sln
@@ -1,16 +1,21 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.DIToolKit", "AspNetCore.DIToolKit\AspNetCore.DIToolKit.csproj", "{EA2BD0E0-98D2-4855-9EEE-186B63316470}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.DIToolKit", "AspNetCore.DIToolKit\\AspNetCore.DIToolKit.csproj", "{EA2BD0E0-98D2-4855-9EEE-186B63316470}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.DIToolKit.Tests", "AspNetCore.DIToolKit.Tests\\AspNetCore.DIToolKit.Tests.csproj", "{96071487-089D-4034-8179-39E9DF985B0E}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EA2BD0E0-98D2-4855-9EEE-186B63316470}.Release|Any CPU.Build.0 = Release|Any CPU
+                {96071487-089D-4034-8179-39E9DF985B0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {96071487-089D-4034-8179-39E9DF985B0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {96071487-089D-4034-8179-39E9DF985B0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {96071487-089D-4034-8179-39E9DF985B0E}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add xUnit test project for AspNetCore.DIToolKit
- verify `ConfigureServicesByLifeTimeCycle` assigns singleton, scoped, and transient lifetimes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892e2174640832b9d800e7afeb3c35a